### PR TITLE
Set lang code to match i18n locale

### DIFF
--- a/app/instance-initializers/lang-code.js
+++ b/app/instance-initializers/lang-code.js
@@ -1,0 +1,11 @@
+export function initialize(appInstance) {
+  const i18nService = appInstance.lookup('service:i18n');
+
+  if (i18nService && i18nService.get('locale')) {
+    document.documentElement.setAttribute('lang', i18nService.get('locale'));
+  }
+}
+
+export default {
+  initialize
+};

--- a/tests/acceptance/application-flow-test.js
+++ b/tests/acceptance/application-flow-test.js
@@ -42,6 +42,8 @@ module('Acceptance | application flow', function(hooks) {
     await visit('/');
     await a11yAudit();
 
+    assert.equal(document.documentElement.getAttribute('lang'), 'en', 'initializer sets lang code on document for screen readers');
+
     await triggerEvent('[data-test-lookup-congress]', 'submit');
     await a11yAudit();
 


### PR DESCRIPTION
Using a lang code helps with screenreader pronunication.

Even though only English is currently supported, we should
still use the language that matches the i18n library so
that if we add support for other locales moving forward,
everything will continue to work seamlessly.