### PR TITLE
Accept wider variety of district ID formats.

### DIFF
--- a/backend/app/server.js
+++ b/backend/app/server.js
@@ -164,13 +164,13 @@ function getDistricts(geography) {
 
 function getRepresentatives(districts) {
   const district = districts.districts[0];
-  const districtIsAtLarge = Number(district.number) === AT_LARGE_DISTRICT_NUMBER;
+  const districtIsAtLarge = district.number === AT_LARGE_DISTRICT_NUMBER;
 
   return performGETRequest({ url: HOUSE_BASE_URL, headers: PROPUBLICA_HEADERS }, result => {
     const allMembers = result.results[0].members;
 
     const repsForDistrict = allMembers.filter(member => {
-      return member.state === district.state && (districtIsAtLarge || member.district === district.number);
+      return member.state === district.state && (districtIsAtLarge || Number(member.district) === district.number);
     });
 
     const representatives = repsForDistrict.map(representative => {
@@ -285,7 +285,7 @@ app.get('/api/congress-from-district', (req, res) => {
       return;
     }
 
-    const stateNumberPattern = /^([a-zA-z]{2})-([0-9]+)$/;
+    const stateNumberPattern = /^([a-zA-z]{2})-?([0-9]+)$/;
     const match = districtID.match(stateNumberPattern);
 
     if (match === null) {
@@ -293,10 +293,11 @@ app.get('/api/congress-from-district', (req, res) => {
       return;
     }
 
-    const [, state, number] = match;
+    const [, state, rawNumber] = match;
+    const number = Number(rawNumber);
     const district = {
       districts: [
-        { state, number, id: districtID }
+        { state, number, id: `${state}-${number}` }
       ]
     };
 

--- a/backend/tests/fixtures/api.js
+++ b/backend/tests/fixtures/api.js
@@ -413,6 +413,60 @@ const CONGRESS_RESPONSE = {
   ]
 };
 
+const SINGLE_DIGIT_DISTRICT_CONGRESS_RESPONSE = {
+  district: {
+    districts: [
+      {
+        state: 'CA',
+        number: '2',
+        id: 'CA-2'
+      }
+    ]
+  },
+  representatives: [
+    {
+      person: {
+        firstname: 'Jared',
+        lastname: 'Huffman'
+      },
+      title: 'Rep.',
+      party: 'Democrat',
+      phone: '202-225-5161',
+      twitter: 'RepHuffman',
+      govtrack: '412511',
+      cspan: '622431',
+      next_election: '2018'
+    }
+  ],
+  senators: [
+    {
+      person: {
+        firstname: 'Dianne',
+        lastname: 'Feinstein'
+      },
+      title: 'Sen.',
+      party: 'Democrat',
+      phone: '202-224-3841',
+      twitter: 'SenFeinstein',
+      govtrack: '300043',
+      cspan: '13061',
+      next_election: '2018'
+    }, {
+      person: {
+        firstname: 'Kamala',
+        lastname: 'Harris'
+      },
+      title: 'Sen.',
+      party: 'Democrat',
+      phone: '202-224-3553',
+      twitter: 'SenKamalaHarris',
+      govtrack: '412678',
+      cspan: '1018696',
+      next_election: '2022'
+    }
+  ]
+};
+
 const AT_LARGE_CONGRESS_RESPONSE = {
   district: {
     districts: [
@@ -508,5 +562,6 @@ module.exports = {
   NON_VOTING_DISTRICT_RESPONSE,
   CONGRESS_RESPONSE,
   AT_LARGE_CONGRESS_RESPONSE,
-  NON_VOTING_AT_LARGE_CONGRESS_RESPONSE
+  NON_VOTING_AT_LARGE_CONGRESS_RESPONSE,
+  SINGLE_DIGIT_DISTRICT_CONGRESS_RESPONSE
 };

--- a/backend/tests/server-test.js
+++ b/backend/tests/server-test.js
@@ -171,6 +171,24 @@ describe('server', function() {
           .expect(200, fixtures.CONGRESS_RESPONSE, done);
       });
 
+      it('handles district id without dash', function testSlash(done) {
+        stubRequest(validRepresentativeURL, houseFixtures.REPRESENTATIVES);
+        stubRequest(validSenatorURL, senateFixtures.SENATORS);
+
+        supertest(this.server)
+          .get('/api/congress-from-district?id=CA02')
+          .expect(200, fixtures.SINGLE_DIGIT_DISTRICT_CONGRESS_RESPONSE, done);
+      });
+
+      it('handles district id with leading zero', function testSlash(done) {
+        stubRequest(validRepresentativeURL, houseFixtures.REPRESENTATIVES);
+        stubRequest(validSenatorURL, senateFixtures.SENATORS);
+
+        supertest(this.server)
+          .get('/api/congress-from-district?id=CA-02')
+          .expect(200, fixtures.SINGLE_DIGIT_DISTRICT_CONGRESS_RESPONSE, done);
+      });
+
       it('with a state with an at-large district, returns correctly formatted response', function testSlash(done) {
         stubRequest(validRepresentativeURL, houseFixtures.REPRESENTATIVES);
         stubRequest(validSenatorURL, senateFixtures.SENATORS);


### PR DESCRIPTION
Allows users to specify formats like

* CA-02
* CA02
* CA2
* CA-2

All of these IDs will return a valid response for that district, but the displayed permalink will still indicate a preference for CA-2.

Closes #53.