### PR TITLE
Implement app-memory level caching, add logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ This app is deployed to two separate dynos on Heroku. The first (`call-my-congre
 
 `call-my-congress` proxies all `/api/` requests to `call-my-congress-backend`, which is defined in [`static.json`](static.json).
 
+### Caching Strategy
+
+Call My Congress relies on third-party APIs to serve district and congressional data. When Call My Congress is experiencing a high volume of traffic, we want to ensure we don't overwhelm our third-party APIs with requests or hit their designated rate limits.
+
+Since most of the response data (congressional representatives, their contact information, and mapping zip codes to districts) does not change on a frequent basis, we can cache the responses and avoid making additional requests for the same data.
+
+Zip code to district data is cached by zip code lookup, and held for one week.
+
+Congressional representative data is cached by either House or Senate, and held for one day.
+
+The current cache implementation uses only app memory (which means each server starts with a completely empty cache when it refreshes, and multiple servers running the app cannot share a cache). We should consider adding a database (like Redis) to further enable Call My Congress to scale in the future if the app-memory cache hits the top of its constraints.
+
+__Note:__ We will _never_ cache or log district lookup by street address, as this is personally-identifiable information and unique to the point that there aren't any gains to be made. Zip code lookups are sufficiently de-anonymized and general to warrant caching.
+
 ### Contributing
 
 PRs and improvements are welcome! If you'd like to contribute but aren't sure where to start, here's a short wish list of small contributions:

--- a/backend/app/api-cache.js
+++ b/backend/app/api-cache.js
@@ -1,0 +1,132 @@
+/* eslint-env node */
+/* global Promise */
+
+const { zipCodeToNonVotingUSPSCode } = require('./non-voting-districts');
+const { getValueFromCache, storeValueInCache, MILLISECONDS_IN_DAY, MILLISECONDS_IN_WEEK } = require('./cache');
+const { buildURL, performGETRequest } = require('./utils');
+
+const CURRENT_CONGRESS = 115;
+const HOUSE_BASE_URL = `https://api.propublica.org/congress/v1/${CURRENT_CONGRESS}/house/members.json`;
+const SENATOR_BASE_URL = `https://api.propublica.org/congress/v1/${CURRENT_CONGRESS}/senate/members.json`;
+const ZIP_ONLY_BASE_URL = 'http://whoismyrepresentative.com/getall_mems.php';
+
+const PROPUBLICA_HEADERS = {
+  'X-API-Key': process.env.PROPUBLICA_API_KEY
+};
+
+// When zip code is not found, the response succeeds with code 200 but the body
+// has this message instead of a JSON object.
+const ZIP_ONLY_ERROR_BODY = `<result message='No Data Found' />`;
+const AT_LARGE_DISTRICT_NUMBER = 0;
+
+const REPRESNTATIVES_CACHE_KEY = 'HOUSE_OF_REPRESENTATIVES';
+const SENATORS_CACHE_KEY = 'SENATE';
+
+function fetchAllRepresentatives() {
+  const cachedRepresentatives = getValueFromCache(REPRESNTATIVES_CACHE_KEY);
+
+  if (cachedRepresentatives) {
+    return new Promise((resolve) => resolve(cachedRepresentatives));
+  }
+
+  return performGETRequest({ url: HOUSE_BASE_URL, headers: PROPUBLICA_HEADERS }, result => {
+    const allMembers = result.results[0].members;
+
+    storeValueInCache(REPRESNTATIVES_CACHE_KEY, allMembers, MILLISECONDS_IN_DAY);
+
+    return allMembers;
+  });
+}
+
+function fetchAllSenators() {
+  const cachedSenators = getValueFromCache(SENATORS_CACHE_KEY);
+
+  if (cachedSenators) {
+    return new Promise((resolve) => resolve(cachedSenators));
+  }
+
+  return performGETRequest({ url: SENATOR_BASE_URL, headers: PROPUBLICA_HEADERS }, result => {
+    const allMembers = result.results[0].members;
+
+    storeValueInCache(SENATORS_CACHE_KEY, allMembers, MILLISECONDS_IN_DAY);
+
+    return allMembers;
+  });
+}
+
+function fetchDistrictsForZip(zip) {
+  const zipCacheKey = `ZIP_${zip}`;
+  const cachedDistricts = getValueFromCache(zipCacheKey);
+
+  if (cachedDistricts) {
+    return new Promise((resolve) => resolve(cachedDistricts));
+  }
+
+  const params = { output: 'json', zip };
+
+  return performGETRequest({ url: buildURL(ZIP_ONLY_BASE_URL, params) }, rawResult => {
+    const districts = transformZipResultToDistricts(rawResult, zip);
+
+    if (!districts) {
+      return null;
+    }
+
+    storeValueInCache(zipCacheKey, districts, MILLISECONDS_IN_WEEK);
+    return districts;
+  });
+}
+
+function transformZipResultToDistricts(body, zip) {
+  if (body === ZIP_ONLY_ERROR_BODY) {
+    // Current API used for zip-only addresses does not handle non-voting
+    // congressional districts. Manually verify if the given zip belongs
+    // to a non-voting district, and if so return that district. Otherwise,
+    // zip code does not map to any district and is invalid.
+    const state = zipCodeToNonVotingUSPSCode(zip);
+
+    if (state !== null) {
+      const number = AT_LARGE_DISTRICT_NUMBER;
+
+      return [
+        {
+          state,
+          number,
+          id: `${state}-${number}`
+        }
+      ];
+    }
+
+    // Zip cannot be mapped to a valid district.
+    return null;
+  }
+
+  const result = typeof body === 'string' ? JSON.parse(body) : body;
+  const state = result.results[0].state;
+
+  const districtNumbers = result.results
+    .map(representative => representative.district)
+    // Filter out all non-numeric districts (i.e. "Junior Seat" for senators)
+    .filter(district => district && !isNaN(district));
+
+  if (state && districtNumbers.length === 0) {
+    districtNumbers.push(AT_LARGE_DISTRICT_NUMBER);
+  }
+
+  return districtNumbers.map(number => {
+    return {
+      state,
+      number,
+      id: `${state}-${number}`
+    };
+  });
+}
+
+module.exports = {
+  fetchAllRepresentatives,
+  fetchAllSenators,
+  fetchDistrictsForZip,
+  transformZipResultToDistricts,
+  HOUSE_BASE_URL,
+  SENATOR_BASE_URL,
+  ZIP_ONLY_BASE_URL
+};

--- a/backend/app/cache.js
+++ b/backend/app/cache.js
@@ -1,0 +1,51 @@
+/* eslint-env node */
+
+const { getLogger } = require('./utils');
+
+const MILLISECONDS_IN_SECOND = 1000;
+const SECONDS_IN_MINUTE = 60;
+const MINUTES_IN_HOUR = 60;
+const HOURS_IN_DAY = 24;
+const DAYS_IN_WEEK = 7;
+
+const MILLISECONDS_IN_HOUR = MILLISECONDS_IN_SECOND * SECONDS_IN_MINUTE * MINUTES_IN_HOUR;
+const MILLISECONDS_IN_DAY = MILLISECONDS_IN_HOUR * HOURS_IN_DAY;
+const MILLISECONDS_IN_WEEK = MILLISECONDS_IN_DAY * DAYS_IN_WEEK;
+
+const log = getLogger();
+const cache = {};
+
+function getValueFromCache(key) {
+  const cachedRecord = cache[key];
+
+  if (cachedRecord && cachedRecord.expiryTimestamp) {
+    if (Date.now() <= cachedRecord.expiryTimestamp) {
+      log.info(`[cache] hit for ${key}`);
+      return cachedRecord.value;
+    }
+
+    log.info(`[cache] hit for ${key}, but was expired (${new Date(cachedRecord.expiryTimestamp)})`);
+    delete cache[key];
+    return null;
+  }
+
+  log.info(`[cache] miss for ${key}`);
+  return null;
+}
+
+function storeValueInCache(key, value, expiryMS = MILLISECONDS_IN_DAY) {
+  const expiryTimestamp = Date.now() + expiryMS;
+  log.info(`[cache] cached value for ${key}, expiryTimestamp=${new Date(expiryTimestamp)}`);
+  cache[key] = {
+    expiryTimestamp,
+    value
+  };
+}
+
+module.exports = {
+  MILLISECONDS_IN_HOUR,
+  MILLISECONDS_IN_DAY,
+  MILLISECONDS_IN_WEEK,
+  getValueFromCache,
+  storeValueInCache
+};

--- a/backend/app/non-voting-districts.js
+++ b/backend/app/non-voting-districts.js
@@ -1,4 +1,4 @@
-/* jshint node: true */
+/* eslint-env node */
 
 const AMERICAN_SAMOA_CODE = 'AS';
 const GUAM_CODE = 'GU';

--- a/backend/app/server.js
+++ b/backend/app/server.js
@@ -1,48 +1,24 @@
-/* jshint node: true */
+/* eslint-env node */
 /* global Promise */
 
-const request = require('request');
 const express = require('express');
-const querystring = require('querystring');
+
+const { AppError, buildURL, getLogger, performGETRequest } = require('./utils');
+const { fetchAllRepresentatives, fetchAllSenators, fetchDistrictsForZip } = require('./api-cache');
+
+const log = getLogger();
 const app = express();
 
-const { zipCodeToNonVotingUSPSCode } = require('./non-voting-districts');
-
-const CURRENT_CONGRESS = 115;
-
-const HOUSE_BASE_URL = `https://api.propublica.org/congress/v1/${CURRENT_CONGRESS}/house/members.json`;
-const SENATOR_BASE_URL = `https://api.propublica.org/congress/v1/${CURRENT_CONGRESS}/senate/members.json`;
-const GEOGRAPHY_BASE_URL = 'https://geocoding.geo.census.gov/geocoder/geographies/address';
-const ZIP_ONLY_BASE_URL = 'http://whoismyrepresentative.com/getall_mems.php';
-
-// When zip code is not found, the response succeeds with code 200 but the body
-// has this message instead of a JSON object.
-const ZIP_ONLY_ERROR_BODY = `<result message='No Data Found' />`;
+const DEFAULT_PORT = 3000;
 
 const AT_LARGE_DISTRICT_NAME = '(at Large)';
 const AT_LARGE_DISTRICT_NUMBER = 0;
 
-const PROPUBLICA_HEADERS = {
-  'X-API-Key': process.env.PROPUBLICA_API_KEY
-};
-
-const DEFAULT_PORT = 3000;
+const GEOGRAPHY_BASE_URL = 'https://geocoding.geo.census.gov/geocoder/geographies/address';
 
 // Geography layer that includes information on the 115th Congressional Districts
 // as defined: https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_Current/MapServer/54
 const CONGRESSIONAL_DISTRICTS_LAYER = 54;
-
-function buildURL(base, params) {
-  return `${base}?${querystring.stringify(params)}`;
-}
-
-function AppError(message) {
-  this.name = 'AppError';
-  this.message = message || 'Default Message';
-  this.stack = (new Error()).stack;
-}
-AppError.prototype = Object.create(Error.prototype);
-AppError.prototype.constructor = AppError;
 
 function getPartyName(shorthand) {
   switch(shorthand) {
@@ -52,84 +28,10 @@ function getPartyName(shorthand) {
   }
 }
 
-function performGETRequest(options, processResult, attemptParse = true) {
-  return new Promise((resolve, reject) => {
-    request.get(options, function (error, response, body) {
-      try {
-        if (!error && response.statusCode === 200) {
-          if (attemptParse) {
-            const result = JSON.parse(body);
-            resolve(processResult(result));
-          } else {
-            resolve(processResult(body));
-          }
-        } else {
-          reject(error);
-        }
-      } catch (error) {
-        reject(error);
-      }
-    });
-  });
-}
-
-function getDistrictsZipOnly(geography) {
-  const params = {
-    output: 'json',
-    zip: geography.zip
-  };
-
-  return performGETRequest({ url: buildURL(ZIP_ONLY_BASE_URL, params) }, body => {
-
-    if (body === ZIP_ONLY_ERROR_BODY) {
-      // Current API used for zip-only addresses does not handle non-voting
-      // congressional districts. Manually verify if the given zip belongs
-      // to a non-voting district, and if so return that district. Otherwise,
-      // zip code does not map to any district and is invalid.
-      const state = zipCodeToNonVotingUSPSCode(geography.zip);
-
-      if (state !== null) {
-        const number = AT_LARGE_DISTRICT_NUMBER;
-
-        return {
-          districts: [
-            {
-              state,
-              number,
-              id: `${state}-${number}`
-            }
-          ]
-        };
-      }
-
-      throw new AppError('INVALID_ADDRESS');
-    }
-
-    const result = JSON.parse(body);
-    const state = result.results[0].state;
-
-    const districtNumbers = result.results
-      .map(representative => representative.district)
-      // Filter out all non-numeric districts (i.e. "Junior Seat" for senators)
-      .filter(district => district && !isNaN(district));
-
-    if (state && districtNumbers.length === 0) {
-      districtNumbers.push(AT_LARGE_DISTRICT_NUMBER);
-    }
-
-    const districts = districtNumbers.map(number => {
-      return {
-        state,
-        number,
-        id: `${state}-${number}`
-      };
-    });
-
-    return { districts };
-  }, false);
-}
-
 function getDistricts(geography) {
+  // Be careful not to log actual street here, to protect privacy of users
+  log.info(`[app] getDistricts, zip=${geography.zip}`);
+
   const params = {
     benchmark: 'Public_AR_Current',
     vintage: 'Current_Current',
@@ -162,13 +64,22 @@ function getDistricts(geography) {
   });
 }
 
-function getRepresentatives(districts) {
-  const district = districts.districts[0];
+function getDistrictsZipOnly(geography) {
+  log.info(`[app] getDistrictsZipOnly, zip=${geography.zip}`);
+
+  return fetchDistrictsForZip(geography.zip).then(districts => {
+    if (districts === null) {
+      throw new AppError('INVALID_ADDRESS');
+    }
+
+    return { districts };
+  }, false);
+}
+
+function getRepresentatives(district) {
   const districtIsAtLarge = district.number === AT_LARGE_DISTRICT_NUMBER;
 
-  return performGETRequest({ url: HOUSE_BASE_URL, headers: PROPUBLICA_HEADERS }, result => {
-    const allMembers = result.results[0].members;
-
+  return fetchAllRepresentatives().then(allMembers => {
     const repsForDistrict = allMembers.filter(member => {
       return member.state === district.state && (districtIsAtLarge || Number(member.district) === district.number);
     });
@@ -200,11 +111,8 @@ function getRepresentatives(districts) {
 }
 
 
-function getSenators(districts) {
-  const district = districts.districts[0];
-
-  return performGETRequest({ url: SENATOR_BASE_URL, headers: PROPUBLICA_HEADERS }, result => {
-    const allMembers = result.results[0].members;
+function getSenators(district) {
+  return fetchAllSenators().then(allMembers => {
     const senatorsForDistrict = allMembers.filter(member => member.state === district.state);
 
     const senators = senatorsForDistrict.map(senator => {
@@ -234,23 +142,30 @@ function getSenators(districts) {
 }
 
 function buildCongress(district) {
+  log.info(`[app] buildCongress, district=${district.id}`);
+
   return Promise.all([
     getRepresentatives(district),
-    getSenators(district),
-    Promise.resolve(district)
+    getSenators(district)
   ])
   .then(congress => {
     const representatives = congress[0].representatives;
     const senators = congress[1].senators;
-    const district = congress[2];
 
     if (senators.length === 0 && representatives.length === 0) {
       throw new AppError('INVALID_STATE');
     }
 
-    return { representatives, senators, district };
+    return {
+      representatives,
+      senators,
+      district: {
+        districts: [district]
+      }
+    };
   });
 }
+
 
 app.get('/api/district-from-address', (req, res) => {
   res.setHeader('Content-Type', 'application/json');
@@ -295,11 +210,7 @@ app.get('/api/congress-from-district', (req, res) => {
 
     const [, state, rawNumber] = match;
     const number = Number(rawNumber);
-    const district = {
-      districts: [
-        { state, number, id: `${state}-${number}` }
-      ]
-    };
+    const district = { state, number, id: `${state}-${number}` };
 
     buildCongress(district)
       .then(congress => res.send(congress))
@@ -314,7 +225,7 @@ app.get('/api/congress-from-district', (req, res) => {
 
 const server = app.listen(process.env.PORT || DEFAULT_PORT, function () {
   const port = server.address().port;
-  console.log(`CallMyCongress server listening at port ${port}`);
+  log.info(`CallMyCongress server listening at port ${port}`);
 });
 
 module.exports = server;

--- a/backend/app/utils.js
+++ b/backend/app/utils.js
@@ -1,0 +1,56 @@
+/* eslint-env node */
+/* global Promise */
+
+const request = require('request');
+const querystring = require('querystring');
+const Log = require('log');
+
+function AppError(message) {
+  this.name = 'AppError';
+  this.message = message || 'Default Message';
+  this.stack = (new Error()).stack;
+}
+AppError.prototype = Object.create(Error.prototype);
+AppError.prototype.constructor = AppError;
+
+function buildURL(base, params) {
+  return `${base}?${querystring.stringify(params)}`;
+}
+
+function performGETRequest(options, processResult, attemptParse = true) {
+  return new Promise((resolve, reject) => {
+    request.get(options, function (error, response, body) {
+      try {
+        if (!error && response.statusCode === 200) {
+          if (attemptParse) {
+            const result = JSON.parse(body);
+            resolve(processResult(result));
+          } else {
+            resolve(processResult(body));
+          }
+        } else {
+          reject(error);
+        }
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}
+
+function getLogger() {
+  const loglevel = process.env.LOGLEVEL;
+
+  if (loglevel) {
+    return new Log(loglevel);
+  }
+
+  return new Log();
+}
+
+module.exports = {
+  AppError,
+  buildURL,
+  getLogger,
+  performGETRequest
+};

--- a/backend/tests/api-cache-test.js
+++ b/backend/tests/api-cache-test.js
@@ -1,0 +1,193 @@
+/* eslint-env node */
+/* global describe,it,before,after */
+
+const { transformZipResultToDistricts, HOUSE_BASE_URL, SENATOR_BASE_URL } = require('../app/api-cache');
+const proxyquire =  require('proxyquire').noCallThru();
+const assert = require('assert');
+const sinon = require('sinon');
+const request = require('request');
+const fixtures = require('./fixtures/api');
+const senateFixtures = require('./fixtures/senate');
+const houseFixtures = require('./fixtures/house');
+
+const ZIP_URL = 'http://whoismyrepresentative.com/getall_mems.php?output=json&zip=20500';
+
+const VALID_RESPONSE = { statusCode: 200 };
+let requests = {};
+
+function stubRequest(url, body, error = false, response = VALID_RESPONSE) {
+  requests[url] = [error, response, body];
+}
+
+describe('API Cache', function() {
+  before(function() {
+    sinon.stub(request, 'get').callsFake(function(options, callback) {
+      if (requests[options.url]) {
+        callback(...requests[options.url]);
+      } else {
+        throw new Error(`No stubbed response defined for ${options.url}`);
+      }
+    });
+  });
+
+  after(function() {
+    request.get.restore();
+  });
+
+  describe('fetchAllRepresentatives', function() {
+    before(function() {
+      stubRequest(HOUSE_BASE_URL, houseFixtures.RAW_RESPONSE);
+    });
+
+    it('passes exact value if cache hits', function(done) {
+      const getValueSpy = sinon.stub().returns(houseFixtures.REPRESENTATIVES);
+      const storeValueSpy = sinon.spy();
+      const apiCache = proxyquire('../app/api-cache', {
+        './cache': {
+          getValueFromCache: getValueSpy,
+          storeValueInCache: storeValueSpy
+        }
+      });
+
+      apiCache.fetchAllRepresentatives().then(result => {
+        assert.deepEqual(result, houseFixtures.REPRESENTATIVES);
+        done();
+      });
+    });
+
+    it('makes request and stores result if cache misses', function(done) {
+      const getValueSpy = sinon.stub().returns(null);
+      const storeValueSpy = sinon.spy();
+      const apiCache = proxyquire('../app/api-cache', {
+        './cache': {
+          getValueFromCache: getValueSpy,
+          storeValueInCache: storeValueSpy
+        }
+      });
+
+      apiCache.fetchAllRepresentatives().then(result => {
+        assert.deepEqual(result, houseFixtures.REPRESENTATIVES);
+        assert.ok(storeValueSpy.calledOnce);
+        assert.deepEqual(storeValueSpy.firstCall.args[1], houseFixtures.REPRESENTATIVES);
+        done();
+      });
+    });
+  });
+
+  describe('fetchAllSenators', function() {
+    before(function() {
+      stubRequest(SENATOR_BASE_URL, senateFixtures.RAW_RESPONSE);
+    });
+
+    it('passes exact value if cache hits', function(done) {
+      const getValueSpy = sinon.stub().returns(senateFixtures.SENATORS);
+      const storeValueSpy = sinon.spy();
+      const apiCache = proxyquire('../app/api-cache', {
+        './cache': {
+          getValueFromCache: getValueSpy,
+          storeValueInCache: storeValueSpy
+        }
+      });
+
+      apiCache.fetchAllSenators().then(result => {
+        assert.deepEqual(result, senateFixtures.SENATORS);
+        done();
+      });
+    });
+
+    it('makes request and stores result if cache misses', function(done) {
+      const getValueSpy = sinon.stub().returns(null);
+      const storeValueSpy = sinon.spy();
+      const apiCache = proxyquire('../app/api-cache', {
+        './cache': {
+          getValueFromCache: getValueSpy,
+          storeValueInCache: storeValueSpy
+        }
+      });
+
+      apiCache.fetchAllSenators().then(result => {
+        assert.deepEqual(result, senateFixtures.SENATORS);
+        assert.ok(storeValueSpy.calledOnce);
+        assert.deepEqual(storeValueSpy.firstCall.args[1], senateFixtures.SENATORS);
+        done();
+      });
+    });
+  });
+
+  describe('fetchDistrictsForZip', function() {
+    before(function() {
+      stubRequest(ZIP_URL, fixtures.ZIP_ONLY_DISTRICT);
+    });
+
+    it('passes exact value if cache hits', function(done) {
+      const getValueSpy = sinon.stub().returns(fixtures.DISTRICT_RESPONSE);
+      const storeValueSpy = sinon.spy();
+      const apiCache = proxyquire('../app/api-cache', {
+        './cache': {
+          getValueFromCache: getValueSpy,
+          storeValueInCache: storeValueSpy
+        }
+      });
+
+      apiCache.fetchDistrictsForZip(20500).then(result => {
+        assert.deepEqual(result, fixtures.DISTRICT_RESPONSE);
+        done();
+      });
+    });
+
+    it('makes request and stores result if cache misses', function(done) {
+      const getValueSpy = sinon.stub().returns(null);
+      const storeValueSpy = sinon.spy();
+      const apiCache = proxyquire('../app/api-cache', {
+        './cache': {
+          getValueFromCache: getValueSpy,
+          storeValueInCache: storeValueSpy
+        }
+      });
+
+      apiCache.fetchDistrictsForZip(20500).then(result => {
+        assert.deepEqual(result, fixtures.DISTRICT_RESPONSE.districts);
+        assert.ok(storeValueSpy.calledOnce);
+        assert.deepEqual(storeValueSpy.firstCall.args[1], fixtures.DISTRICT_RESPONSE.districts);
+        done();
+      });
+    });
+  });
+
+  describe('transformZipResultToDistricts', function() {
+    it('with successful API calls, returns correctly formatted response', function() {
+      assert.deepEqual(
+        transformZipResultToDistricts(fixtures.ZIP_ONLY_DISTRICT, fixtures.SINGLE_DISTRICT_ZIP_CODE),
+        fixtures.DISTRICT_RESPONSE.districts
+      );
+    });
+
+    it('returns correctly formatted response for zip that could be in multiple districts', function() {
+      assert.deepEqual(
+        transformZipResultToDistricts(fixtures.ZIP_ONLY_WITH_TWO_DISTRICTS, fixtures.TWO_DISTRICT_ZIP_CODE),
+        fixtures.TWO_DISTRICTS_RESPONSE.districts
+      );
+    });
+
+    it('returns correctly formatted response for zip in state with a single at-large district', function() {
+      assert.deepEqual(
+        transformZipResultToDistricts(fixtures.ZIP_ONLY_WITH_AT_LARGE_DISTRICT),
+        fixtures.AT_LARGE_DISTRICT_RESPONSE.districts
+      );
+    });
+
+    it('with failed API calls, returns null', function() {
+      assert.deepEqual(
+        transformZipResultToDistricts(`<result message='No Data Found' />`),
+        null
+      );
+    });
+
+    it('with failed API calls, matching a non-voting district, returns correctly formatted response', function() {
+      assert.deepEqual(
+        transformZipResultToDistricts(`<result message='No Data Found' />`, fixtures.NON_VOTING_ZIP_CODE),
+        fixtures.NON_VOTING_DISTRICT_RESPONSE.districts
+      );
+    });
+  });
+});

--- a/backend/tests/cache-test.js
+++ b/backend/tests/cache-test.js
@@ -1,0 +1,34 @@
+/* eslint-env node */
+/* global describe,it,beforeEach,afterEach */
+
+const { getValueFromCache, storeValueInCache } = require('../app/cache');
+const assert = require('assert');
+const sinon = require('sinon');
+
+describe('Cache', function() {
+  beforeEach(function() {
+    this.clock = sinon.useFakeTimers();
+  })
+
+  afterEach(function() {
+    this.clock.restore();
+  })
+
+  it('handles adding and getting values from cache', function() {
+    const cacheKey = 'someCacheKey';
+
+    assert.equal(getValueFromCache(cacheKey), null, 'value starts out as null');
+
+    storeValueInCache(cacheKey, 'hello world', 1000);
+
+    assert.equal(getValueFromCache(cacheKey), 'hello world', 'retrieves value after it is set');
+
+    this.clock.tick(500);
+
+    assert.equal(getValueFromCache(cacheKey), 'hello world', 'retrieves value while still fresh');
+
+    this.clock.tick(501);
+
+    assert.equal(getValueFromCache(cacheKey), null, 'value is cleared after timestamp expires');
+  });
+});

--- a/backend/tests/fixtures/api.js
+++ b/backend/tests/fixtures/api.js
@@ -1,4 +1,4 @@
-/* jshint node: true */
+/* eslint-env node */
 
 const DISTRICT_OBJECT = {
   result: {
@@ -550,6 +550,9 @@ const NON_VOTING_AT_LARGE_CONGRESS_RESPONSE = {
 };
 
 module.exports = {
+  SINGLE_DISTRICT_ZIP_CODE: 94102,
+  TWO_DISTRICT_ZIP_CODE: 77035,
+  NON_VOTING_ZIP_CODE: 20201,
   DISTRICT,
   AT_LARGE_DISTRICT,
   NON_VOTING_DISTRICT,

--- a/backend/tests/fixtures/house.js
+++ b/backend/tests/fixtures/house.js
@@ -1,7 +1,6 @@
-  /* jshint node: true */
+/* eslint-env node */
 
-  module.exports = {
-    REPRESENTATIVES: `{
+ const RAW_RESPONSE = `{
      "status":"OK",
      "copyright":" Copyright (c) 2017 Pro Publica Inc. All Rights Reserved.",
      "results":[
@@ -17730,5 +17729,9 @@
                ]
         }
      ]
-  }`
+  }`;
+
+module.exports = {
+  RAW_RESPONSE,
+  REPRESENTATIVES: JSON.parse(RAW_RESPONSE).results[0].members
 };

--- a/backend/tests/fixtures/senate.js
+++ b/backend/tests/fixtures/senate.js
@@ -1,7 +1,6 @@
-/* jshint node: true */
+/* eslint-env node */
 
-module.exports = {
-  SENATORS: `{
+const RAW_RESPONSE = `{
     "status": "OK",
     "copyright": " Copyright (c) 2017 Pro Publica Inc. All Rights Reserved.",
     "results": [
@@ -4155,5 +4154,9 @@ module.exports = {
         ]
       }
     ]
-  }`
+  }`;
+
+module.exports = {
+  RAW_RESPONSE,
+  SENATORS: JSON.parse(RAW_RESPONSE).results[0].members
 };

--- a/backend/tests/non-voting-districts-test.js
+++ b/backend/tests/non-voting-districts-test.js
@@ -1,3 +1,6 @@
+/* eslint-env node */
+/* global describe,it */
+
 const { zipCodeToNonVotingUSPSCode } = require('../app/non-voting-districts');
 const assert = require('assert');
 

--- a/backend/tests/server-test.js
+++ b/backend/tests/server-test.js
@@ -1,8 +1,9 @@
-/* jshint node: true */
-/* global describe,before,beforeEach,after,afterEach,it */
+/* eslint-env node */
+/* global Promise,describe,before,beforeEach,after,afterEach,it */
 
 const request = require('request');
 const supertest = require('supertest');
+const proxyquire =  require('proxyquire').noCallThru();
 const sinon = require('sinon');
 const fixtures = require('./fixtures/api');
 const senateFixtures = require('./fixtures/senate');
@@ -11,6 +12,11 @@ const houseFixtures = require('./fixtures/house');
 const VALID_RESPONSE = { statusCode: 200 };
 
 let requests = {};
+let apiCacheStubs = {
+  fetchAllRepresentatives() { return Promise.resolve(); },
+  fetchAllSenators() { return Promise.resolve(); },
+  fetchDistrictsForZip() { return Promise.resolve(); }
+};
 
 function stubRequest(url, body, error = false, response = VALID_RESPONSE) {
   requests[url] = [error, response, body];
@@ -22,15 +28,27 @@ describe('server', function() {
       if (requests[options.url]) {
         callback(...requests[options.url]);
       } else {
-        console.log(options.url);
         throw new Error(`No stubbed response defined for ${options.url}`);
       }
     });
   });
+
   beforeEach(function() {
     requests = {};
     process.env.PORT = 3001;
-    this.server = require('../app/server');
+    this.server = proxyquire('../app/server', {
+      './api-cache': {
+        fetchAllRepresentatives() {
+          return apiCacheStubs.fetchAllRepresentatives();
+        },
+        fetchAllSenators() {
+          return apiCacheStubs.fetchAllSenators();
+        },
+        fetchDistrictsForZip() {
+          return apiCacheStubs.fetchDistrictsForZip();
+        }
+      }
+    });
   });
 
   afterEach(function() {
@@ -46,7 +64,7 @@ describe('server', function() {
       const apiURL = 'https://geocoding.geo.census.gov/geocoder/geographies/address?benchmark=Public_AR_Current&vintage=Current_Current&format=json&layers=54&street=1600%20Pennsylvania%20Ave&zip=20500';
       const serverURL = '/api/district-from-address?street=1600%20Pennsylvania%20Ave&zip=20500';
 
-      it('with successful API calls, returns correctly formatted response', function testSlash(done) {
+      it('with successful API calls, returns correctly formatted response', function(done) {
         stubRequest(apiURL, fixtures.DISTRICT);
 
         supertest(this.server)
@@ -54,7 +72,7 @@ describe('server', function() {
           .expect(200, fixtures.DISTRICT_RESPONSE, done);
       });
 
-      it('returns correctly formatted response for address that in state with a single at-large district', function testSlash(done) {
+      it('returns correctly formatted response for address that in state with a single at-large district', function(done) {
         stubRequest(apiURL, fixtures.AT_LARGE_DISTRICT);
 
         supertest(this.server)
@@ -62,7 +80,7 @@ describe('server', function() {
           .expect(200, fixtures.AT_LARGE_DISTRICT_RESPONSE, done);
       });
 
-      it('returns correctly formatted response for address that in non-voting district', function testSlash(done) {
+      it('returns correctly formatted response for address that in non-voting district', function(done) {
         stubRequest(apiURL, fixtures.NON_VOTING_DISTRICT);
 
         supertest(this.server)
@@ -70,7 +88,7 @@ describe('server', function() {
           .expect(200, fixtures.NON_VOTING_DISTRICT_RESPONSE, done);
       });
 
-      it('with failed API calls, returns correctly formatted error response', function testSlash(done) {
+      it('with failed API calls, returns correctly formatted error response', function(done) {
         stubRequest(apiURL, { message: 'failed with some error' }, true);
 
         supertest(this.server)
@@ -78,7 +96,7 @@ describe('server', function() {
           .expect(500, { translationKey: 'UNKNOWN' }, done);
       });
 
-      it('with invalid API calls, returns correctly formatted error response', function testSlash(done) {
+      it('with invalid API calls, returns correctly formatted error response', function(done) {
         stubRequest(apiURL, 'unexpected successful response type');
 
         supertest(this.server)
@@ -87,68 +105,46 @@ describe('server', function() {
       });
 
       describe('providing only zip code', function() {
-        const apiURL = 'http://whoismyrepresentative.com/getall_mems.php?output=json&zip=20500';
         const serverURL = '/api/district-from-address?zip=20500';
 
-        it('with successful API calls, returns correctly formatted response', function testSlash(done) {
-          stubRequest(apiURL, fixtures.ZIP_ONLY_DISTRICT);
+        it('with valid zip, returns correctly formatted response', function(done) {
+          apiCacheStubs.fetchDistrictsForZip = () => new Promise(resolve => resolve(fixtures.DISTRICT_RESPONSE.districts));
 
           supertest(this.server)
             .get(serverURL)
             .expect(200, fixtures.DISTRICT_RESPONSE, done);
         });
 
-        it('returns correctly formatted response for zip that could be in multiple districts', function testSlash(done) {
-          stubRequest(apiURL, fixtures.ZIP_ONLY_WITH_TWO_DISTRICTS);
+        it('with invalid zip, returns error response', function(done) {
+          apiCacheStubs.fetchDistrictsForZip = () => new Promise(resolve => resolve(null));
+
+          stubRequest(apiURL, fixtures.ZIP_ONLY_DISTRICT);
 
           supertest(this.server)
             .get(serverURL)
-            .expect(200, fixtures.TWO_DISTRICTS_RESPONSE, done);
-        });
-
-        it('returns correctly formatted response for zip in state with a single at-large district', function testSlash(done) {
-          stubRequest(apiURL, fixtures.ZIP_ONLY_WITH_TWO_DISTRICTS);
-
-          supertest(this.server)
-            .get(serverURL)
-            .expect(200, fixtures.TWO_DISTRICTS_RESPONSE, done);
-        });
-
-        it('with successful API calls, returns correctly formatted response with two districts', function testSlash(done) {
-          stubRequest(apiURL, fixtures.ZIP_ONLY_WITH_AT_LARGE_DISTRICT);
-
-          supertest(this.server)
-            .get(serverURL)
-            .expect(200, fixtures.AT_LARGE_DISTRICT_RESPONSE, done);
-        });
-
-        it('with failed API calls, returns correctly formatted error response', function testSlash(done) {
-          stubRequest('http://whoismyrepresentative.com/getall_mems.php?output=json&zip=99999',
-                      `<result message='No Data Found' />`);
-
-          supertest(this.server)
-            .get('/api/district-from-address?zip=99999')
             .expect(500, { translationKey: 'INVALID_ADDRESS' }, done);
         });
 
-        it('with failed API calls, matching a non-voting district, returns correctly formatted response', function testSlash(done) {
-          stubRequest(apiURL, `<result message='No Data Found' />`);
+        it('with error in fetching districts, returns generic error response', function(done) {
+          apiCacheStubs.fetchDistrictsForZip = () => new Promise((_, reject) => reject('some error'));
+
+          stubRequest(apiURL, fixtures.ZIP_ONLY_DISTRICT);
 
           supertest(this.server)
             .get(serverURL)
-            .expect(200, fixtures.NON_VOTING_DISTRICT_RESPONSE, done);
+            .expect(500, { translationKey: 'UNKNOWN' }, done);
         });
       });
     });
 
     describe('with invalid params', function() {
-      it('with missing zip, returns correctly formatted error response', function testSlash(done) {
+      it('with missing zip, returns correctly formatted error response', function(done) {
         supertest(this.server)
           .get('/api/district-from-address?street=1600%20%Pennsylvania%20Ave')
           .expect(400, { translationKey: 'MISSING_ZIP' }, done);
       });
 
-      it('with no query params, returns correctly formatted error response', function testSlash(done) {
+      it('with no query params, returns correctly formatted error response', function(done) {
         supertest(this.server)
           .get('/api/district-from-address')
           .expect(400, { translationKey: 'MISSING_ZIP' }, done);
@@ -157,68 +153,57 @@ describe('server', function() {
   });
 
   describe('/api/congress-from-district', function() {
-    const validRepresentativeURL = 'https://api.propublica.org/congress/v1/115/house/members.json';
-    const validSenatorURL = 'https://api.propublica.org/congress/v1/115/senate/members.json';
     const serverURL = '/api/congress-from-district?id=CA-12';
 
     describe('with valid params', function() {
-      it('with successful API calls, returns correctly formatted response', function testSlash(done) {
-        stubRequest(validRepresentativeURL, houseFixtures.REPRESENTATIVES);
-        stubRequest(validSenatorURL, senateFixtures.SENATORS);
+      it('with successful API calls, returns correctly formatted response', function(done) {
+        apiCacheStubs.fetchAllSenators = () => new Promise(resolve => resolve(senateFixtures.SENATORS));
+        apiCacheStubs.fetchAllRepresentatives = () => new Promise(resolve => resolve(houseFixtures.REPRESENTATIVES));
 
         supertest(this.server)
           .get(serverURL)
           .expect(200, fixtures.CONGRESS_RESPONSE, done);
       });
 
-      it('handles district id without dash', function testSlash(done) {
-        stubRequest(validRepresentativeURL, houseFixtures.REPRESENTATIVES);
-        stubRequest(validSenatorURL, senateFixtures.SENATORS);
+      it('handles district id without dash', function(done) {
+        apiCacheStubs.fetchAllSenators = () => new Promise(resolve => resolve(senateFixtures.SENATORS));
+        apiCacheStubs.fetchAllRepresentatives = () => new Promise(resolve => resolve(houseFixtures.REPRESENTATIVES));
 
         supertest(this.server)
           .get('/api/congress-from-district?id=CA02')
           .expect(200, fixtures.SINGLE_DIGIT_DISTRICT_CONGRESS_RESPONSE, done);
       });
 
-      it('handles district id with leading zero', function testSlash(done) {
-        stubRequest(validRepresentativeURL, houseFixtures.REPRESENTATIVES);
-        stubRequest(validSenatorURL, senateFixtures.SENATORS);
+      it('handles district id with leading zero', function(done) {
+        apiCacheStubs.fetchAllSenators = () => new Promise(resolve => resolve(senateFixtures.SENATORS));
+        apiCacheStubs.fetchAllRepresentatives = () => new Promise(resolve => resolve(houseFixtures.REPRESENTATIVES));
 
         supertest(this.server)
           .get('/api/congress-from-district?id=CA-02')
           .expect(200, fixtures.SINGLE_DIGIT_DISTRICT_CONGRESS_RESPONSE, done);
       });
 
-      it('with a state with an at-large district, returns correctly formatted response', function testSlash(done) {
-        stubRequest(validRepresentativeURL, houseFixtures.REPRESENTATIVES);
-        stubRequest(validSenatorURL, senateFixtures.SENATORS);
+      it('with a state with an at-large district, returns correctly formatted response', function(done) {
+        apiCacheStubs.fetchAllSenators = () => new Promise(resolve => resolve(senateFixtures.SENATORS));
+        apiCacheStubs.fetchAllRepresentatives = () => new Promise(resolve => resolve(houseFixtures.REPRESENTATIVES));
 
         supertest(this.server)
           .get('/api/congress-from-district?id=AK-0')
           .expect(200, fixtures.AT_LARGE_CONGRESS_RESPONSE, done);
       });
 
-      it('with a non-voting state with an at-large district, returns correctly formatted response', function testSlash(done) {
-        stubRequest(validRepresentativeURL, houseFixtures.REPRESENTATIVES);
-        stubRequest(validSenatorURL, senateFixtures.SENATORS);
+      it('with a non-voting state with an at-large district, returns correctly formatted response', function(done) {
+        apiCacheStubs.fetchAllSenators = () => new Promise(resolve => resolve(senateFixtures.SENATORS));
+        apiCacheStubs.fetchAllRepresentatives = () => new Promise(resolve => resolve(houseFixtures.REPRESENTATIVES));
 
         supertest(this.server)
           .get('/api/congress-from-district?id=PR-0')
           .expect(200, fixtures.NON_VOTING_AT_LARGE_CONGRESS_RESPONSE, done);
       });
 
-      it('with failed API calls, returns correctly formatted error response', function testSlash(done) {
-        stubRequest(validRepresentativeURL, { message: 'failed with some error' }, true);
-        stubRequest(validSenatorURL, { message: 'another error' }, true);
-
-        supertest(this.server)
-          .get(serverURL)
-          .expect(500, { translationKey: 'UNKNOWN' }, done);
-      });
-
-      it('with invalid API calls, returns correctly formatted error response', function testSlash(done) {
-        stubRequest(validRepresentativeURL, 'unexpected successful response type');
-        stubRequest(validSenatorURL, 'unexpected error response type', true);
+      it('with failed API calls, returns correctly formatted error response', function(done) {
+        apiCacheStubs.fetchAllSenators = () => new Promise((_, reject) => reject('some error'));
+        apiCacheStubs.fetchAllRepresentatives = () => new Promise((_, reject) => reject('some error'));
 
         supertest(this.server)
           .get(serverURL)
@@ -227,19 +212,19 @@ describe('server', function() {
     });
 
     describe('with invalid params', function() {
-      it('with random string for id, returns correctly formatted error response', function testSlash(done) {
+      it('with random string for id, returns correctly formatted error response', function(done) {
         supertest(this.server)
           .get('/api/congress-from-district?id=not-a-valid-id')
           .expect(400, { translationKey: 'INVALID_DISTRICT_ID' }, done);
       });
 
-      it('with invalid state, returns correctly formatted error response', function testSlash(done) {
+      it('with invalid state, returns correctly formatted error response', function(done) {
         supertest(this.server)
           .get('/api/congress-from-district?id=LOL-12')
           .expect(400, { translationKey: 'INVALID_DISTRICT_ID' }, done);
       });
 
-      it('with no query params, returns correctly formatted error response', function testSlash(done) {
+      it('with no query params, returns correctly formatted error response', function(done) {
         supertest(this.server)
           .get('/api/congress-from-district')
           .expect(400, { translationKey: 'MISSING_DISTRICT_ID' }, done);

--- a/package.json
+++ b/package.json
@@ -52,12 +52,14 @@
     "loader.js": "4.7.0",
     "mocha": "5.2.0",
     "nodemon": "1.18.3",
+    "proxyquire": "^2.0.1",
     "sinon": "6.0.1",
     "supertest": "3.1.0"
   },
   "dependencies": {
     "ember-source": "3.3.0",
     "express": "4.14.0",
+    "log": "^1.4.0",
     "request": "2.87.0"
   }
 }


### PR DESCRIPTION
In order to prevent sending the same requests to the
third-party APIs that power CallMyCongress.com over and
over again during high-volume traffic times, implement
a simple caching strategy that stores the processed requests
in app memory for either one day (congress contact data)
or one week (zip code to district data).

Add additional logging to the backend app and rearrange
some file structure to help with debugging and clarity
of code.

This strategy does have some downsides. The cache is lost
every time the server restarts; if we store many zip codes,
we may use too much app memory; if multiple servers are
running, they all have their own separate cache. To address
further problems of scale, should consider adding a database
to hold the cache (such as redis); actual cache implementation
can be abstracted away easily thanks to the new cache module.